### PR TITLE
Fix: Comments - Adjust single response field name

### DIFF
--- a/projects/comment.go
+++ b/projects/comment.go
@@ -406,7 +406,7 @@ type CommentGetRequestPath struct {
 
 // CommentGetRequest represents the request body for loading a single comment.
 //
-// No public documentation available yet.
+// https://apidocs.teamwork.com/docs/teamwork/v3/comments/get-projects-api-v3-comments-id-json
 type CommentGetRequest struct {
 	// Path contains the path parameters for the request.
 	Path CommentGetRequestPath
@@ -436,9 +436,9 @@ func (t CommentGetRequest) HTTPRequest(ctx context.Context, server string) (*htt
 
 // CommentGetResponse contains all the information related to a comment.
 //
-// No public documentation available yet.
+// https://apidocs.teamwork.com/docs/teamwork/v3/comments/get-projects-api-v3-comments-id-json
 type CommentGetResponse struct {
-	Comment Comment `json:"comment"`
+	Comment Comment `json:"comments"`
 }
 
 // HandleHTTPResponse handles the HTTP response for the CommentGetResponse. If
@@ -504,6 +504,7 @@ type CommentListRequestFilters struct {
 
 // CommentListRequest represents the request body for loading multiple comments.
 //
+// https://apidocs.teamwork.com/docs/teamwork/v3/comments/get-projects-api-v3-comments-json
 // https://apidocs.teamwork.com/docs/teamwork/v3/file-version-comments/get-projects-api-v3-fileversions-id-comments-json
 // https://apidocs.teamwork.com/docs/teamwork/v3/milestone-comments/get-projects-api-v3-milestones-milestone-id-comments-json
 // https://apidocs.teamwork.com/docs/teamwork/v3/notebook-comments/get-projects-api-v3-notebooks-notebook-id-comments-json

--- a/projects/comment_example_test.go
+++ b/projects/comment_example_test.go
@@ -178,7 +178,7 @@ func startCommentServer() (string, func(), error) {
 		}
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{"comment":{"id":12345}}`)
+		_, _ = fmt.Fprintln(w, `{"comments":{"id":12345}}`)
 	})
 	mux.HandleFunc("GET /projects/api/v3/comments", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Description

There's a typo in the API when retrieving a single comment, where the property is named `comments` instead of `comment`. There's already some good usage on this endpoint, so it's not possible to fix it now without breaking backwards compatibility.

<img width="2136" height="960" alt="image" src="https://github.com/user-attachments/assets/7b4554e9-b78a-44f1-bd68-672a6ce03267" />

https://apidocs.teamwork.com/docs/teamwork/v3/comments/get-projects-api-v3-comments-id-json

Also adding missing links for the documentation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors