### PR TITLE
Enhancement: Add SiteOwner and InOwnerCompany fields to User struct

### DIFF
--- a/projects/user.go
+++ b/projects/user.go
@@ -92,6 +92,19 @@ type User struct {
 	UpdatedAt *time.Time `json:"updatedAt"`
 }
 
+// UserMe represents an special type for the logged user.
+type UserMe struct {
+	User
+
+	// SiteOwner indicates whether the user is the account owner. The site owner
+	// has full control over the account and its settings.
+	SiteOwner bool `json:"siteOwner"`
+
+	// InOwnerCompany indicates whether the user is in the owner company. Users in
+	// owner companies typically have different permissions.
+	InOwnerCompany bool `json:"inOwnerCompany"`
+}
+
 // UserCreateRequest represents the request body for creating a new
 // user.
 //
@@ -447,7 +460,7 @@ func (u UserGetMeRequest) HTTPRequest(ctx context.Context, server string) (*http
 //
 // https://apidocs.teamwork.com/docs/teamwork/v3/people/get-projects-api-v3-me-json
 type UserGetMeResponse struct {
-	User User `json:"person"`
+	User UserMe `json:"person"`
 }
 
 // HandleHTTPResponse handles the HTTP response for the UserGetMeResponse. If


### PR DESCRIPTION
## Description

Expose `siteOwner` and `inOwnerCompany` flags returned by the API so clients can identify the account owner and whether a user belongs to the owner company.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors