### PR TITLE
Fix: Timer - Project should be an optional field when updating

### DIFF
--- a/projects/timer.go
+++ b/projects/timer.go
@@ -212,23 +212,23 @@ type TimerUpdateRequest struct {
 	Path TimerUpdateRequestPath `json:"-"`
 
 	// Description is a brief summary of the timer's purpose.
-	Description *string `json:"description"`
+	Description *string `json:"description,omitempty"`
 
 	// Billable indicates whether the timer is billable.
-	Billable *bool `json:"isBillable"`
+	Billable *bool `json:"isBillable,omitempty"`
 
 	// Running indicates whether the timer is currently running.
-	Running *bool `json:"isRunning"`
+	Running *bool `json:"isRunning,omitempty"`
 
 	// StopRunningTimers indicates whether to stop all running timers.
-	StopRunningTimers *bool `json:"stopRunningTimers"`
+	StopRunningTimers *bool `json:"stopRunningTimers,omitempty"`
 
 	// ProjectID is the unique identifier of the project associated with the
 	// timer. The ProjectID must be provided.
-	ProjectID int64 `json:"projectId"`
+	ProjectID *int64 `json:"projectId,omitempty"`
 
 	// TaskID is the unique identifier of the task associated with the timer.
-	TaskID *int64 `json:"taskId"`
+	TaskID *int64 `json:"taskId,omitempty"`
 }
 
 // NewTimerUpdateRequest creates a new TimerUpdateRequest with the

--- a/projects/timer_test.go
+++ b/projects/timer_test.go
@@ -82,7 +82,7 @@ func TestTimerUpdate(t *testing.T) {
 			Description: twapi.Ptr("Updated description"),
 			Billable:    twapi.Ptr(true),
 			Running:     twapi.Ptr(true),
-			ProjectID:   testResources.ProjectID,
+			ProjectID:   &testResources.ProjectID,
 			TaskID:      &testResources.TaskID,
 		},
 	}}


### PR DESCRIPTION
## Description

Even though the endpoint uses a `PUT` method, it behaves like a `PATCH`, so we should keep all fields optional and omit them when not provided in the payload.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors