### PR TITLE
Fix: Activity log item type decoding

### DIFF
--- a/projects/activity.go
+++ b/projects/activity.go
@@ -125,39 +125,48 @@ const (
 	LogItemTypeBudget           LogItemType = "budget"
 )
 
+// keep a map with logItemTypes in lowercase for fast case insensitive matching
+var logItemTypes = map[string]LogItemType{
+	"message":           LogItemTypeMessage,
+	"comment":           LogItemTypeComment,
+	"task":              LogItemTypeTask,
+	"tasklist":          LogItemTypeTasklist,
+	"taskgroup":         LogItemTypeTaskgroup,
+	"milestone":         LogItemTypeMilestone,
+	"file":              LogItemTypeFile,
+	"form":              LogItemTypeForm,
+	"notebook":          LogItemTypeNotebook,
+	"timelog":           LogItemTypeTimelog,
+	"task_comment":      LogItemTypeTaskComment,
+	"notebook_comment":  LogItemTypeNotebookComment,
+	"file_comment":      LogItemTypeFileComment,
+	"link_comment":      LogItemTypeLinkComment,
+	"milestone_comment": LogItemTypeMilestoneComment,
+	"project":           LogItemTypeProject,
+	"link":              LogItemTypeLink,
+	"billinginvoice":    LogItemTypeBillingInvoice,
+	"risk":              LogItemTypeRisk,
+	"projectupdate":     LogItemTypeProjectUpdate,
+	"reacted":           LogItemTypeReacted,
+	"budget":            LogItemTypeBudget,
+}
+
 // UnmarshalText decodes the text into a LogItemType.
 func (l *LogItemType) UnmarshalText(text []byte) error {
 	if l == nil {
 		panic("unmarshal LogItemType: nil pointer")
 	}
-	logItemType := LogItemType(strings.ToLower(string(text)))
-	switch logItemType {
-	case LogItemTypeMessage,
-		LogItemTypeComment,
-		LogItemTypeTask,
-		LogItemTypeTasklist,
-		LogItemTypeTaskgroup,
-		LogItemTypeMilestone,
-		LogItemTypeFile,
-		LogItemTypeForm,
-		LogItemTypeNotebook,
-		LogItemTypeTimelog,
-		LogItemTypeTaskComment,
-		LogItemTypeNotebookComment,
-		LogItemTypeFileComment,
-		LogItemTypeLinkComment,
-		LogItemTypeMilestoneComment,
-		LogItemTypeProject,
-		LogItemTypeLink,
-		LogItemTypeBillingInvoice,
-		LogItemTypeRisk,
-		LogItemTypeProjectUpdate,
-		LogItemTypeReacted,
-		LogItemTypeBudget:
-		*l = logItemType
-	default:
+
+	normalizedText := string(text)
+	normalizedText = strings.TrimSpace(normalizedText)
+	normalizedText = strings.ToLower(normalizedText)
+
+	logItemType, ok := logItemTypes[normalizedText]
+	if !ok {
 		return fmt.Errorf("invalid log item type: %q", text)
 	}
+
+	*l = logItemType
 	return nil
 }
 

--- a/projects/activity_test.go
+++ b/projects/activity_test.go
@@ -39,3 +39,76 @@ func TestActivityList(t *testing.T) {
 		})
 	}
 }
+func TestLogItemType_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []byte
+		want        projects.LogItemType
+		expectError bool
+	}{
+		{
+			name:  "valid lowercase",
+			input: []byte("task"),
+			want:  projects.LogItemTypeTask,
+		},
+		{
+			name:  "valid uppercase",
+			input: []byte("TASK"),
+			want:  projects.LogItemTypeTask,
+		},
+		{
+			name:  "valid mixed case with spaces",
+			input: []byte("  TaskList "),
+			want:  projects.LogItemTypeTasklist,
+		},
+		{
+			name:  "underscore type",
+			input: []byte("task_comment"),
+			want:  projects.LogItemTypeTaskComment,
+		},
+		{
+			name:  "camelcase type",
+			input: []byte("billingInvoice"),
+			want:  projects.LogItemTypeBillingInvoice,
+		},
+		{
+			name:        "invalid type",
+			input:       []byte("unknown"),
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			input:       []byte(""),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var l projects.LogItemType
+			err := l.UnmarshalText(tt.input)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error for input %q, got nil", tt.input)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for input %q: %v", tt.input, err)
+				}
+				if l != tt.want {
+					t.Errorf("got %q, want %q", l, tt.want)
+				}
+			}
+		})
+	}
+
+	t.Run("nil receiver panics", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("expected panic on nil receiver, got none")
+			}
+		}()
+		var l *projects.LogItemType
+		_ = l.UnmarshalText([]byte("task"))
+	})
+}


### PR DESCRIPTION
## Description

When decoding the log item type from an activity, there was an issue with camelCase types, as the algorithm always lower-cased the input.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors