### PR TITLE
Feature: Tasks - Support marking tasks as complete

### DIFF
--- a/projects/task.go
+++ b/projects/task.go
@@ -20,6 +20,8 @@ var (
 	_ twapi.HTTPResponser = (*TaskUpdateResponse)(nil)
 	_ twapi.HTTPRequester = (*TaskDeleteRequest)(nil)
 	_ twapi.HTTPResponser = (*TaskDeleteResponse)(nil)
+	_ twapi.HTTPRequester = (*TaskCompleteRequest)(nil)
+	_ twapi.HTTPResponser = (*TaskCompleteResponse)(nil)
 	_ twapi.HTTPRequester = (*TaskGetRequest)(nil)
 	_ twapi.HTTPResponser = (*TaskGetResponse)(nil)
 	_ twapi.HTTPRequester = (*TaskListRequest)(nil)
@@ -491,6 +493,67 @@ func TaskDelete(
 	req TaskDeleteRequest,
 ) (*TaskDeleteResponse, error) {
 	return twapi.Execute[TaskDeleteRequest, *TaskDeleteResponse](ctx, engine, req)
+}
+
+// TaskCompleteRequestPath contains the path parameters for completing a task.
+type TaskCompleteRequestPath struct {
+	// ID is the unique identifier of the task to be marked as complete.
+	ID int64
+}
+
+// TaskCompleteRequest represents the request body for completing a task.
+//
+// https://apidocs.teamwork.com/docs/teamwork/v1/tasks/put-tasks-id-complete-json
+type TaskCompleteRequest struct {
+	// Path contains the path parameters for the request.
+	Path TaskCompleteRequestPath `json:"-"`
+}
+
+// NewTaskCompleteRequest creates a new TaskCompleteRequest with the provided
+// task ID. The ID is required to complete a task.
+func NewTaskCompleteRequest(taskID int64) TaskCompleteRequest {
+	return TaskCompleteRequest{
+		Path: TaskCompleteRequestPath{
+			ID: taskID,
+		},
+	}
+}
+
+// HTTPRequest creates an HTTP request for the TaskCompleteRequest.
+func (t TaskCompleteRequest) HTTPRequest(ctx context.Context, server string) (*http.Request, error) {
+	uri := server + "/tasks/" + strconv.FormatInt(t.Path.ID, 10) + "/complete.json"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// TaskCompleteResponse represents the response body for completing a task.
+//
+// https://apidocs.teamwork.com/docs/teamwork/v1/tasks/put-tasks-id-complete-json
+type TaskCompleteResponse struct{}
+
+// HandleHTTPResponse handles the HTTP response for the TaskCompleteResponse.
+// If some unexpected HTTP status code is returned by the API, a twapi.HTTPError
+// is returned.
+func (t *TaskCompleteResponse) HandleHTTPResponse(resp *http.Response) error {
+	if resp.StatusCode != http.StatusOK {
+		return twapi.NewHTTPError(resp, "failed to complete task")
+	}
+	return nil
+}
+
+// TaskComplete marks a task as complete using the provided request and returns
+// the response.
+func TaskComplete(
+	ctx context.Context,
+	engine *twapi.Engine,
+	req TaskCompleteRequest,
+) (*TaskCompleteResponse, error) {
+	return twapi.Execute[TaskCompleteRequest, *TaskCompleteResponse](ctx, engine, req)
 }
 
 // TaskGetRequestPath contains the path parameters for loading a single task.

--- a/projects/task_example_test.go
+++ b/projects/task_example_test.go
@@ -81,6 +81,27 @@ func ExampleTaskDelete() {
 	// Output: task deleted!
 }
 
+func ExampleTaskComplete() {
+	address, stop, err := startTaskServer() // mock server for demonstration purposes
+	if err != nil {
+		fmt.Printf("failed to start server: %s", err)
+		return
+	}
+	defer stop()
+
+	ctx := context.Background()
+	engine := twapi.NewEngine(session.NewBearerToken("your_token", fmt.Sprintf("http://%s", address)))
+
+	_, err = projects.TaskComplete(ctx, engine, projects.NewTaskCompleteRequest(12345))
+	if err != nil {
+		fmt.Printf("failed to complete task: %s", err)
+	} else {
+		fmt.Println("task completed!")
+	}
+
+	// Output: task completed!
+}
+
 func ExampleTaskGet() {
 	address, stop, err := startTaskServer() // mock server for demonstration purposes
 	if err != nil {
@@ -170,6 +191,15 @@ func startTaskServer() (string, func(), error) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprintln(w, `{"affected":{"taskIds":[12345]}}`)
+	})
+	mux.HandleFunc("PUT /tasks/{id}/complete", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("id") != "12345" {
+			http.Error(w, "Not Found", http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintln(w, `{"STATUS":"OK"}`)
 	})
 	mux.HandleFunc("GET /projects/api/v3/tasks/{id}", func(w http.ResponseWriter, r *http.Request) {
 		if r.PathValue("id") != "12345" {

--- a/projects/task_test.go
+++ b/projects/task_test.go
@@ -188,6 +188,26 @@ func TestTaskDelete(t *testing.T) {
 	}
 }
 
+func TestTaskComplete(t *testing.T) {
+	if engine == nil {
+		t.Skip("Skipping test because the engine is not initialized")
+	}
+
+	taskID, taskCleanup, err := createTask(t, testResources.TasklistID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(taskCleanup)
+
+	ctx := t.Context()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	t.Cleanup(cancel)
+
+	if _, err = projects.TaskComplete(ctx, engine, projects.NewTaskCompleteRequest(taskID)); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
 func TestTaskGet(t *testing.T) {
 	if engine == nil {
 		t.Skip("Skipping test because the engine is not initialized")


### PR DESCRIPTION
Adds TaskComplete request/response types and a TaskComplete function that issues PUT /tasks/{id}/complete.json against the v1 Teamwork API, mirroring the existing TimerComplete pattern.

## Description
<!-- Briefly describe what this PR does and why it's needed -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [X] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed the code
- [X] Added necessary documentation
- [X] No new warnings or errors