### PR TITLE
Fix: Failing to move task to a specific stage

### DIFF
--- a/projects/workflow_stage_task.go
+++ b/projects/workflow_stage_task.go
@@ -38,6 +38,11 @@ type WorkflowStageTaskMoveRequest struct {
 
 	// StageID is the identifier of the stage to which the task will be moved to.
 	StageID int64 `json:"stageId"`
+
+	// PositionAfterTaskID is the identifier of the task after which the current
+	// task will be positioned within the stage. If not provided or set as '-1',
+	// the task will be moved to the end of the stage.
+	PositionAfterTaskID int64 `json:"positionAfterTask,omitempty"`
 }
 
 // NewWorkflowStageTaskMoveRequest creates a new WorkflowStageTaskMoveRequest
@@ -54,6 +59,11 @@ func NewWorkflowStageTaskMoveRequest(workflowID, stageID, taskID int64) Workflow
 
 // HTTPRequest creates an HTTP request for the WorkflowStageTaskMoveRequest.
 func (w WorkflowStageTaskMoveRequest) HTTPRequest(ctx context.Context, server string) (*http.Request, error) {
+	if w.PositionAfterTaskID == 0 || w.PositionAfterTaskID < -1 {
+		// default is to move the task to the end of the stage
+		w.PositionAfterTaskID = -1
+	}
+
 	uri := fmt.Sprintf("%s/projects/api/v3/tasks/%d/workflows/%d.json", server, w.Path.TaskID, w.Path.WorkflowID)
 
 	var body bytes.Buffer

--- a/projects/workflow_stage_task_test.go
+++ b/projects/workflow_stage_task_test.go
@@ -13,6 +13,12 @@ func TestWorkflowStageTaskMove(t *testing.T) {
 		t.Skip("Skipping test because the engine is not initialized")
 	}
 
+	taskID, taskCleanup, err := createTask(t, testResources.TasklistID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(taskCleanup)
+
 	tests := []struct {
 		name  string
 		input projects.WorkflowStageTaskMoveRequest
@@ -23,6 +29,16 @@ func TestWorkflowStageTaskMove(t *testing.T) {
 			testResources.WorkflowStageID,
 			testResources.TaskID,
 		),
+	}, {
+		name: "all fields",
+		input: projects.WorkflowStageTaskMoveRequest{
+			Path: projects.WorkflowStageTaskMoveRequestPath{
+				WorkflowID: testResources.WorkflowID,
+				TaskID:     taskID,
+			},
+			StageID:             testResources.WorkflowStageID,
+			PositionAfterTaskID: testResources.TaskID,
+		},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

The field `positionAfterTask` is required to move a task to a specific workflow stage. Otherwise, the API returns a valid response (204) but doesn't do anything.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors