### PR TITLE
Enhancement: Task option to identify invalid users

### DIFF
--- a/projects/task.go
+++ b/projects/task.go
@@ -127,6 +127,11 @@ type Task struct {
 type TaskOptions struct {
 	// Notify enables notifications for the task actions.
 	Notify bool `json:"notify"`
+	// CheckInvalidusers enables checking for invalid users when assigning the
+	// task. If set to true, the API will return an error if any of the provided
+	// assignees are invalid. If set to false, the API will ignore invalid
+	// assignees and assign the task to valid ones.
+	CheckInvalidUsers bool `json:"checkInvalidusers"`
 }
 
 // TaskPredecessorType defines the predecessor constraint type

--- a/projects/task_test.go
+++ b/projects/task_test.go
@@ -38,7 +38,8 @@ func TestTaskCreate(t *testing.T) {
 				TasklistID: testResources.TasklistID,
 			},
 			Options: projects.TaskOptions{
-				Notify: true,
+				Notify:            true,
+				CheckInvalidUsers: true,
 			},
 			Name:             fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100)),
 			Description:      new("This is a test task"),
@@ -123,7 +124,8 @@ func TestTaskUpdate(t *testing.T) {
 				ID: taskID,
 			},
 			Options: projects.TaskOptions{
-				Notify: true,
+				Notify:            true,
+				CheckInvalidUsers: true,
 			},
 			Name:             new(fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100))),
 			Description:      new("This is a test task"),


### PR DESCRIPTION
## Description

New option when creating or updating a task to alert about invalid users in the payload. By default, invalid user assignees (e.g. not project members) will be silently dropped instead of failing the request.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors