### PR TITLE
Fix: Wrong projects sideload format

### DIFF
--- a/projects/project.go
+++ b/projects/project.go
@@ -722,7 +722,7 @@ type ProjectGetResponse struct {
 		// ProjectCategories contains the categories associated with the project.
 		//
 		// The key is the string representation of the project category ID.
-		ProjectCategories []ProjectCategory `json:"projectCategories"`
+		ProjectCategories map[string]ProjectCategory `json:"projectCategories"`
 	} `json:"included"`
 }
 
@@ -862,7 +862,7 @@ type ProjectListResponse struct {
 		// ProjectCategories contains the categories associated with the project.
 		//
 		// The key is the string representation of the project category ID.
-		ProjectCategories []ProjectCategory `json:"projectCategories"`
+		ProjectCategories map[string]ProjectCategory `json:"projectCategories"`
 	} `json:"included"`
 }
 

--- a/projects/project_test.go
+++ b/projects/project_test.go
@@ -288,6 +288,15 @@ func TestProjectList(t *testing.T) {
 		input projects.ProjectListRequest
 	}{{
 		name: "all projects",
+		input: projects.ProjectListRequest{
+			Filters: projects.ProjectListRequestFilters{
+				ProjectRequestFilters: projects.ProjectRequestFilters{
+					Include: []projects.ProjectRequestSideload{
+						projects.ProjectRequestSideloadProjectCategories,
+					},
+				},
+			},
+		},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

> failed to decode list projects response: json: cannot unmarshal object into Go struct field .included.projectCategories of type []projects.ProjectCategory

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors