### PR TITLE
Fix: Comment sideload has a different format from the main entity

### DIFF
--- a/projects/comment.go
+++ b/projects/comment.go
@@ -83,6 +83,29 @@ type Comment struct {
 	DeletedAt *time.Time `json:"dateDeleted"`
 }
 
+// CommentSideload contains minimal information about a comment, used for
+// sideloading in other API responses.
+type CommentSideload struct {
+	// ID is the unique identifier of the comment.
+	ID int64 `json:"id"`
+
+	// Body is the body of the comment.
+	Body string `json:"title"`
+
+	// Object is the relationship to the object (task, milestone, project) that
+	// this comment is associated with.
+	Object twapi.Relationship `json:"object"`
+
+	// Project is the relationship to the project that this comment belongs to.
+	Project twapi.Relationship `json:"project"`
+
+	// PostedBy is the ID of the user who posted the comment.
+	PostedBy *twapi.Relationship `json:"postedBy"`
+
+	// PostedAt is the date and time when the comment was posted.
+	PostedAt *time.Time `json:"postedDateTime"`
+}
+
 // CommentUpdateRequestPath contains the path parameters for creating a
 // comment.
 type CommentCreateRequestPath struct {

--- a/projects/search.go
+++ b/projects/search.go
@@ -220,7 +220,7 @@ type SearchResponse struct {
 		// Comments contains the comments associated with the search results.
 		//
 		// The key is the string representation of the comment ID.
-		Comments map[string]Comment `json:"comments,omitempty"`
+		Comments map[string]CommentSideload `json:"comments,omitempty"`
 		// Companies contains the companies associated with the search results.
 		//
 		// The key is the string representation of the company ID.


### PR DESCRIPTION
## Description

The response from direct requests to `v3/comments.json` and sideloads is different. This requires different types for each scenario.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors