### PR TITLE
Enhancement: Allow sideloading custom fields

### DIFF
--- a/projects/company.go
+++ b/projects/company.go
@@ -425,6 +425,32 @@ func CompanyDelete(
 	return twapi.Execute[CompanyDeleteRequest, *CompanyDeleteResponse](ctx, engine, req)
 }
 
+// CompanyRequestSideload contains the possible sideload options when loading
+// companies.
+type CompanyRequestSideload string
+
+// List of possible sideload options for CompanyRequestSideload.
+const (
+	CompanyRequestSideloadCompanyCustomFields      CompanyRequestSideload = "customfields"
+	CompanyRequestSideloadCompanyCustomFieldValues CompanyRequestSideload = "customfieldcompanies"
+)
+
+// CompanyRequestFilters contains the filters for loading companies.
+type CompanyRequestFilters struct {
+	// Include specifies related resources to include.
+	Include []CompanyRequestSideload
+}
+
+func (p CompanyRequestFilters) apply(req *http.Request) {
+	query := req.URL.Query()
+	if len(p.Include) > 0 {
+		for _, include := range p.Include {
+			query.Add("include", string(include))
+		}
+	}
+	req.URL.RawQuery = query.Encode()
+}
+
 // CompanyGetRequestPath contains the path parameters for loading a single company.
 type CompanyGetRequestPath struct {
 	// ID is the unique identifier of the company to be retrieved.
@@ -438,6 +464,9 @@ type CompanyGetRequestPath struct {
 type CompanyGetRequest struct {
 	// Path contains the path parameters for the request.
 	Path CompanyGetRequestPath
+
+	// Filters contains the filters for loading a single company.
+	Filters CompanyRequestFilters
 }
 
 // NewCompanyGetRequest creates a new CompanyGetRequest with the provided
@@ -458,6 +487,7 @@ func (c CompanyGetRequest) HTTPRequest(ctx context.Context, server string) (*htt
 	if err != nil {
 		return nil, err
 	}
+	c.Filters.apply(req)
 
 	return req, nil
 }
@@ -467,6 +497,19 @@ func (c CompanyGetRequest) HTTPRequest(ctx context.Context, server string) (*htt
 // https://apidocs.teamwork.com/docs/teamwork/v3/companies/get-projects-api-v3-companies-company-id-json
 type CompanyGetResponse struct {
 	Company Company `json:"company"`
+
+	// Included contains related objects included in the response.
+	Included struct {
+		// CustomFields contains the custom fields associated with the company.
+		//
+		// The key is the string representation of the custom field ID.
+		CustomFields map[string]CustomField `json:"customfields,omitempty"`
+		// CustomFieldValues contains the values of the custom fields associated
+		// with the company.
+		//
+		// The key is the string representation of the custom field value ID.
+		CustomFieldValues map[string]CustomFieldValue `json:"customfieldCompanies,omitempty"`
+	} `json:"included"`
 }
 
 // HandleHTTPResponse handles the HTTP response for the CompanyGetResponse. If
@@ -496,6 +539,8 @@ func CompanyGet(
 // CompanyListRequestFilters contains the filters for loading multiple
 // clients/companies.
 type CompanyListRequestFilters struct {
+	CompanyRequestFilters
+
 	// SearchTerm is an optional search term to filter clients/companies by name.
 	SearchTerm string
 
@@ -514,6 +559,8 @@ type CompanyListRequestFilters struct {
 }
 
 func (c CompanyListRequestFilters) apply(req *http.Request) {
+	c.CompanyRequestFilters.apply(req)
+
 	query := req.URL.Query()
 	if c.SearchTerm != "" {
 		query.Set("searchTerm", c.SearchTerm)
@@ -576,12 +623,28 @@ func (c CompanyListRequest) HTTPRequest(ctx context.Context, server string) (*ht
 type CompanyListResponse struct {
 	request CompanyListRequest
 
+	// Meta contains metadata about the response, including pagination details.
 	Meta struct {
 		Page struct {
 			HasMore bool `json:"hasMore"`
 		} `json:"page"`
 	} `json:"meta"`
+
+	// Companies is the list of companies matching the request filters.
 	Companies []Company `json:"companies"`
+
+	// Included contains related objects included in the response.
+	Included struct {
+		// CustomFields contains the custom fields associated with the company.
+		//
+		// The key is the string representation of the custom field ID.
+		CustomFields map[string]CustomField `json:"customfields,omitempty"`
+		// CustomFieldValues contains the values of the custom fields associated
+		// with the company.
+		//
+		// The key is the string representation of the custom field value ID.
+		CustomFieldValues map[string]CustomFieldValue `json:"customfieldCompanies,omitempty"`
+	} `json:"included"`
 }
 
 // HandleHTTPResponse handles the HTTP response for the CompanyListResponse. If

--- a/projects/project.go
+++ b/projects/project.go
@@ -651,7 +651,9 @@ type ProjectRequestSideload string
 
 // List of possible sideload options for ProjectRequestSideload.
 const (
-	ProjectRequestSideloadProjectCategories ProjectRequestSideload = "projectCategories"
+	ProjectRequestSideloadProjectCategories        ProjectRequestSideload = "projectCategories"
+	ProjectRequestSideloadProjectCustomFields      ProjectRequestSideload = "customfields"
+	ProjectRequestSideloadProjectCustomFieldValues ProjectRequestSideload = "customfieldprojects"
 )
 
 // ProjectRequestFilters contains the filters for loading projects.
@@ -723,6 +725,15 @@ type ProjectGetResponse struct {
 		//
 		// The key is the string representation of the project category ID.
 		ProjectCategories map[string]ProjectCategory `json:"projectCategories,omitempty"`
+		// CustomFields contains the custom fields associated with the project.
+		//
+		// The key is the string representation of the custom field ID.
+		CustomFields map[string]CustomField `json:"customfields,omitempty"`
+		// CustomFieldValues contains the values of the custom fields associated
+		// with the project.
+		//
+		// The key is the string representation of the custom field value ID.
+		CustomFieldValues map[string]CustomFieldValue `json:"customfieldProjects,omitempty"`
 	} `json:"included"`
 }
 
@@ -863,6 +874,15 @@ type ProjectListResponse struct {
 		//
 		// The key is the string representation of the project category ID.
 		ProjectCategories map[string]ProjectCategory `json:"projectCategories,omitempty"`
+		// CustomFields contains the custom fields associated with the project.
+		//
+		// The key is the string representation of the custom field ID.
+		CustomFields map[string]CustomField `json:"customfields,omitempty"`
+		// CustomFieldValues contains the values of the custom fields associated
+		// with the project.
+		//
+		// The key is the string representation of the custom field value ID.
+		CustomFieldValues map[string]CustomFieldValue `json:"customfieldProjects,omitempty"`
 	} `json:"included"`
 }
 

--- a/projects/task.go
+++ b/projects/task.go
@@ -593,6 +593,32 @@ func TaskComplete(
 	return twapi.Execute[TaskCompleteRequest, *TaskCompleteResponse](ctx, engine, req)
 }
 
+// TaskRequestSideload contains the possible sideload options when loading
+// tasks.
+type TaskRequestSideload string
+
+// List of possible sideload options for TaskRequestSideload.
+const (
+	TaskRequestSideloadTaskCustomFields      TaskRequestSideload = "customfields"
+	TaskRequestSideloadTaskCustomFieldValues TaskRequestSideload = "customfieldtasks"
+)
+
+// TaskRequestFilters contains the filters for loading tasks.
+type TaskRequestFilters struct {
+	// Include specifies related resources to include.
+	Include []TaskRequestSideload
+}
+
+func (p TaskRequestFilters) apply(req *http.Request) {
+	query := req.URL.Query()
+	if len(p.Include) > 0 {
+		for _, include := range p.Include {
+			query.Add("include", string(include))
+		}
+	}
+	req.URL.RawQuery = query.Encode()
+}
+
 // TaskGetRequestPath contains the path parameters for loading a single task.
 type TaskGetRequestPath struct {
 	// ID is the unique identifier of the task to be retrieved.
@@ -605,6 +631,9 @@ type TaskGetRequestPath struct {
 type TaskGetRequest struct {
 	// Path contains the path parameters for the request.
 	Path TaskGetRequestPath
+
+	// Filters contains the filters for loading a single task.
+	Filters TaskRequestFilters
 }
 
 // NewTaskGetRequest creates a new TaskGetRequest with the provided
@@ -625,6 +654,7 @@ func (t TaskGetRequest) HTTPRequest(ctx context.Context, server string) (*http.R
 	if err != nil {
 		return nil, err
 	}
+	t.Filters.apply(req)
 
 	return req, nil
 }
@@ -634,6 +664,19 @@ func (t TaskGetRequest) HTTPRequest(ctx context.Context, server string) (*http.R
 // https://apidocs.teamwork.com/docs/teamwork/v3/tasks/get-projects-api-v3-tasks-task-id-json
 type TaskGetResponse struct {
 	Task Task `json:"task"`
+
+	// Included contains related objects included in the response.
+	Included struct {
+		// CustomFields contains the custom fields associated with the task.
+		//
+		// The key is the string representation of the custom field ID.
+		CustomFields map[string]CustomField `json:"customfields,omitempty"`
+		// CustomFieldValues contains the values of the custom fields associated
+		// with the task.
+		//
+		// The key is the string representation of the custom field value ID.
+		CustomFieldValues map[string]CustomFieldValue `json:"customfieldTasks,omitempty"`
+	} `json:"included"`
 }
 
 // HandleHTTPResponse handles the HTTP response for the TaskGetResponse. If some
@@ -672,6 +715,8 @@ type TaskListRequestPath struct {
 
 // TaskListRequestFilters contains the filters for loading multiple tasks.
 type TaskListRequestFilters struct {
+	TaskRequestFilters
+
 	// SearchTerm is an optional search term to filter tasks by name, description
 	// or tasklist's name.
 	SearchTerm string
@@ -722,6 +767,8 @@ type TaskListRequestFilters struct {
 }
 
 func (t TaskListRequestFilters) apply(req *http.Request) {
+	t.TaskRequestFilters.apply(req)
+
 	query := req.URL.Query()
 	if t.SearchTerm != "" {
 		query.Set("searchTerm", t.SearchTerm)
@@ -830,12 +877,28 @@ func (t TaskListRequest) HTTPRequest(ctx context.Context, server string) (*http.
 type TaskListResponse struct {
 	request TaskListRequest
 
+	// Meta contains metadata about the response, including pagination details.
 	Meta struct {
 		Page struct {
 			HasMore bool `json:"hasMore"`
 		} `json:"page"`
 	} `json:"meta"`
+
+	// Tasks is the list of tasks matching the request filters.
 	Tasks []Task `json:"tasks"`
+
+	// Included contains related objects included in the response.
+	Included struct {
+		// CustomFields contains the custom fields associated with the task.
+		//
+		// The key is the string representation of the custom field ID.
+		CustomFields map[string]CustomField `json:"customfields,omitempty"`
+		// CustomFieldValues contains the values of the custom fields associated
+		// with the task.
+		//
+		// The key is the string representation of the custom field value ID.
+		CustomFieldValues map[string]CustomFieldValue `json:"customfieldTasks,omitempty"`
+	} `json:"included"`
 }
 
 // HandleHTTPResponse handles the HTTP response for the TaskListResponse. If


### PR DESCRIPTION
## Description

When requesting information from tasks, companies or projects, allow side-loading custom fields.

Related to:
https://github.com/Teamwork/twapi-go-sdk/pull/81

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors