### PR TITLE
Fix: Include multiple sideloads

### DIFF
--- a/projects/company.go
+++ b/projects/company.go
@@ -444,9 +444,11 @@ type CompanyRequestFilters struct {
 func (p CompanyRequestFilters) apply(req *http.Request) {
 	query := req.URL.Query()
 	if len(p.Include) > 0 {
-		for _, include := range p.Include {
-			query.Add("include", string(include))
+		includes := make([]string, len(p.Include))
+		for i, include := range p.Include {
+			includes[i] = string(include)
 		}
+		query.Set("include", strings.Join(includes, ","))
 	}
 	req.URL.RawQuery = query.Encode()
 }

--- a/projects/project.go
+++ b/projects/project.go
@@ -665,9 +665,11 @@ type ProjectRequestFilters struct {
 func (p ProjectRequestFilters) apply(req *http.Request) {
 	query := req.URL.Query()
 	if len(p.Include) > 0 {
-		for _, include := range p.Include {
-			query.Add("include", string(include))
+		includes := make([]string, len(p.Include))
+		for i, include := range p.Include {
+			includes[i] = string(include)
 		}
+		query.Set("include", strings.Join(includes, ","))
 	}
 	req.URL.RawQuery = query.Encode()
 }

--- a/projects/task.go
+++ b/projects/task.go
@@ -612,9 +612,11 @@ type TaskRequestFilters struct {
 func (p TaskRequestFilters) apply(req *http.Request) {
 	query := req.URL.Query()
 	if len(p.Include) > 0 {
-		for _, include := range p.Include {
-			query.Add("include", string(include))
+		includes := make([]string, len(p.Include))
+		for i, include := range p.Include {
+			includes[i] = string(include)
 		}
+		query.Set("include", strings.Join(includes, ","))
 	}
 	req.URL.RawQuery = query.Encode()
 }


### PR DESCRIPTION
## Description

`query.Add` will repeat the query string parameter multiple times instead of comma concatenating it in the same entry. The approach now is to build the list manually.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors