### PR TITLE
Feat: Switch StartAt and DueAt to date-only format

### DIFF
--- a/projects/task.go
+++ b/projects/task.go
@@ -77,10 +77,10 @@ type Task struct {
 	Progress int64 `json:"progress"`
 
 	// StartAt is the date and time when the task is scheduled to start.
-	StartAt *time.Time `json:"startDate"`
+	StartAt *twapi.Date `json:"startDate"`
 
 	// DueAt is the date and time when the task is scheduled to be completed.
-	DueAt *time.Time `json:"dueDate"`
+	DueAt *twapi.Date `json:"dueDate"`
 
 	// EstimatedMinutes is the estimated time to complete the task, in minutes.
 	EstimatedMinutes int64 `json:"estimateMinutes"`

--- a/projects/task.go
+++ b/projects/task.go
@@ -76,10 +76,10 @@ type Task struct {
 	// Progress is the progress of the task, in percentage (0-100).
 	Progress int64 `json:"progress"`
 
-	// StartAt is the date and time when the task is scheduled to start.
+	// StartAt is the date when the task is scheduled to start.
 	StartAt *twapi.Date `json:"startDate"`
 
-	// DueAt is the date and time when the task is scheduled to be completed.
+	// DueAt is the date when the task is scheduled to be completed.
 	DueAt *twapi.Date `json:"dueDate"`
 
 	// EstimatedMinutes is the estimated time to complete the task, in minutes.

--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -79,6 +80,11 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 	var str string
 	if err := json.Unmarshal(data, &str); err != nil {
 		return err
+	}
+	// temporary workaround in case datetime date is received
+	// should be removed after date-only (projects-task-no-timezone) flag is fully enabled
+	if strings.Contains(str, "T") {
+		str, _, _ = strings.Cut(str, "T")
 	}
 	parsedTime, err := time.Parse("2006-01-02", str)
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -81,8 +81,6 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &str); err != nil {
 		return err
 	}
-	// temporary workaround in case datetime date is received
-	// should be removed after date-only (projects-task-no-timezone) flag is fully enabled
 	if strings.Contains(str, "T") {
 		str, _, _ = strings.Cut(str, "T")
 	}


### PR DESCRIPTION
## Description
<!-- Briefly describe what this PR does and why it's needed -->

Update `Task` response struct to handle `startDate` and `dueDate` of tasks as date-only instead of date-time.

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors