### PR TITLE
Fix: Decode custom field options from nested "options" object

### DIFF
--- a/projects/custom_field.go
+++ b/projects/custom_field.go
@@ -143,9 +143,11 @@ type CustomFieldOptions interface {
 	options()
 }
 
-// CustomFieldOptionsDropdown store the options for a dropdown type.
+// CustomFieldOptionsDropdown store the options for the choice-based custom
+// field types. The API uses this same "choices" shape for dropdown,
+// multiselect and status fields.
 type CustomFieldOptionsDropdown struct {
-	// Choices is the list of choices available for the dropdown.
+	// Choices is the list of choices available for the field.
 	Choices []CustomFieldOptionsDropdownChoice `json:"choices"`
 }
 
@@ -273,22 +275,36 @@ func (c *CustomField) UnmarshalJSON(data []byte) error {
 	}
 	*c = CustomField{customField: customField}
 
+	// The API nests the type-specific options under an "options" object, so
+	// decode that sub-object rather than the whole custom field payload.
+	var wrapper struct {
+		Options json.RawMessage `json:"options"`
+	}
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return err
+	}
+	if len(wrapper.Options) == 0 || string(wrapper.Options) == "null" {
+		return nil
+	}
+
+	// The API serializes the same "choices" shape for dropdown, multiselect
+	// and status fields, so all three decode into the dropdown options type.
 	switch c.Type {
-	case CustomFieldTypeDropdown:
+	case CustomFieldTypeDropdown, CustomFieldTypeMultiselect, CustomFieldTypeStatus:
 		var options CustomFieldOptionsDropdown
-		if err := json.Unmarshal(data, &options); err != nil {
+		if err := json.Unmarshal(wrapper.Options, &options); err != nil {
 			return fmt.Errorf("failed to decode dropdown options: %w", err)
 		}
 		c.Options = options
 	case CustomFieldTypeRating:
 		var options CustomFieldOptionsRating
-		if err := json.Unmarshal(data, &options); err != nil {
+		if err := json.Unmarshal(wrapper.Options, &options); err != nil {
 			return fmt.Errorf("failed to decode rating options: %w", err)
 		}
 		c.Options = options
 	case CustomFieldTypeNumberDecimal:
 		var options CustomFieldOptionsNumberDecimal
-		if err := json.Unmarshal(data, &options); err != nil {
+		if err := json.Unmarshal(wrapper.Options, &options); err != nil {
 			return fmt.Errorf("failed to decode number decimal options: %w", err)
 		}
 		c.Options = options

--- a/projects/custom_field_test.go
+++ b/projects/custom_field_test.go
@@ -2,6 +2,7 @@ package projects_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -177,6 +178,141 @@ func TestCustomFieldList(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %s", err)
 			}
+		})
+	}
+}
+
+func TestCustomFieldUnmarshalJSONOptions(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		verify func(t *testing.T, cf projects.CustomField)
+	}{{
+		name: "dropdown choices nested under options",
+		input: `{
+			"id": 70375,
+			"name": "TestNumbers",
+			"type": "dropdown",
+			"entity": "task",
+			"options": {"choices": [
+				{"value": "1", "color": "#4cd5e3"},
+				{"value": "2", "color": "#e12d42"}
+			]}
+		}`,
+		verify: func(t *testing.T, cf projects.CustomField) {
+			options, ok := cf.Options.(projects.CustomFieldOptionsDropdown)
+			if !ok {
+				t.Fatalf("expected dropdown options, got %T", cf.Options)
+			}
+			if len(options.Choices) != 2 {
+				t.Fatalf("expected 2 choices, got %d", len(options.Choices))
+			}
+			if options.Choices[0].Value != "1" || options.Choices[1].Value != "2" {
+				t.Errorf("unexpected choice values: %+v", options.Choices)
+			}
+		},
+	}, {
+		name: "multiselect choices nested under options",
+		input: `{
+			"id": 71000,
+			"name": "Tags",
+			"type": "multiselect",
+			"entity": "task",
+			"options": {"choices": [
+				{"value": "red", "color": "#4cd5e3"},
+				{"value": "green", "color": "#e12d42"}
+			]}
+		}`,
+		verify: func(t *testing.T, cf projects.CustomField) {
+			options, ok := cf.Options.(projects.CustomFieldOptionsDropdown)
+			if !ok {
+				t.Fatalf("expected dropdown options for multiselect, got %T", cf.Options)
+			}
+			if len(options.Choices) != 2 {
+				t.Fatalf("expected 2 choices, got %d", len(options.Choices))
+			}
+			if options.Choices[0].Value != "red" || options.Choices[1].Value != "green" {
+				t.Errorf("unexpected choice values: %+v", options.Choices)
+			}
+		},
+	}, {
+		name: "status choices nested under options",
+		input: `{
+			"id": 71001,
+			"name": "Stage",
+			"type": "status",
+			"entity": "task",
+			"options": {"choices": [
+				{"value": "open", "color": "#4cd5e3"}
+			]}
+		}`,
+		verify: func(t *testing.T, cf projects.CustomField) {
+			options, ok := cf.Options.(projects.CustomFieldOptionsDropdown)
+			if !ok {
+				t.Fatalf("expected dropdown options for status, got %T", cf.Options)
+			}
+			if len(options.Choices) != 1 || options.Choices[0].Value != "open" {
+				t.Errorf("unexpected choices: %+v", options.Choices)
+			}
+		},
+	}, {
+		name: "rating options nested under options",
+		input: `{
+			"id": 1,
+			"name": "Rating",
+			"type": "rating",
+			"entity": "task",
+			"options": {"icon": "star", "color": "#ff0000"}
+		}`,
+		verify: func(t *testing.T, cf projects.CustomField) {
+			options, ok := cf.Options.(projects.CustomFieldOptionsRating)
+			if !ok {
+				t.Fatalf("expected rating options, got %T", cf.Options)
+			}
+			if options.Icon != "star" {
+				t.Errorf("expected icon 'star', got %q", options.Icon)
+			}
+		},
+	}, {
+		name: "number decimal options nested under options",
+		input: `{
+			"id": 2,
+			"name": "Decimal",
+			"type": "number-decimal",
+			"entity": "task",
+			"options": {"decimals": 3}
+		}`,
+		verify: func(t *testing.T, cf projects.CustomField) {
+			options, ok := cf.Options.(projects.CustomFieldOptionsNumberDecimal)
+			if !ok {
+				t.Fatalf("expected number decimal options, got %T", cf.Options)
+			}
+			if options.DecimalPoints == nil || *options.DecimalPoints != 3 {
+				t.Errorf("expected 3 decimal points, got %v", options.DecimalPoints)
+			}
+		},
+	}, {
+		name: "missing options is not an error",
+		input: `{
+			"id": 3,
+			"name": "Text",
+			"type": "text-short",
+			"entity": "task"
+		}`,
+		verify: func(t *testing.T, cf projects.CustomField) {
+			if cf.Options != nil {
+				t.Errorf("expected nil options, got %+v", cf.Options)
+			}
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cf projects.CustomField
+			if err := json.Unmarshal([]byte(tt.input), &cf); err != nil {
+				t.Fatalf("failed to unmarshal custom field: %s", err)
+			}
+			tt.verify(t, cf)
 		})
 	}
 }


### PR DESCRIPTION
## Description

`CustomField.UnmarshalJSON` decoded the type-specific options by unmarshalling the entire custom-field payload, which looked for a top-level "choices" key. The API nests options under an "options" object, so `Choices` (and rating/decimal options) always decoded to nil — surfacing as `"options":{"choices":null}` for callers that round-trip through the struct, while raw passthrough paths showed the choices correctly.

Decode the nested "options" value and unmarshal that into the concrete options type instead. A missing or null options object is no longer treated as an error.

Additionally, the API serialises the same "choices" shape for dropdown, multiselect and status fields, but only dropdown was decoded — multiselect and status silently lost their choices. Decode all three into the dropdown options type.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors