### PR TITLE
Enhancement: Task - Add filters for completed tasks and tasklists

### DIFF
--- a/projects/query.go
+++ b/projects/query.go
@@ -1,0 +1,77 @@
+package projects
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	twapi "github.com/teamwork/twapi-go-sdk"
+)
+
+// Helpers for building list-request query strings. They follow the shape of
+// twapi.ApplySparseFields — take the query, the parameter name and the value —
+// and centralise the "skip unset values" rule that every filter's apply method
+// would otherwise spell out inline. Each helper is a no-op when the value is
+// unset, so the API's default behaviour is preserved.
+
+// querySetString sets key to value, skipping the empty string. It is generic
+// over ~string so the typed enums used by filters (order-by keys, sideloads,
+// status values) can be passed without an explicit conversion.
+func querySetString[T ~string](query url.Values, key string, value T) {
+	if value == "" {
+		return
+	}
+	query.Set(key, string(value))
+}
+
+// querySetInt64 sets key to value, skipping non-positive values. Every non-pointer
+// int64 filter in the SDK identifies real entities or pagination bounds, where
+// zero and negative values mean "unset" rather than a value to send. A filter
+// that must be able to send zero needs a *int64 and its own helper.
+func querySetInt64(query url.Values, key string, value int64) {
+	if value <= 0 {
+		return
+	}
+	query.Set(key, strconv.FormatInt(value, 10))
+}
+
+// querySetTimestamp sets key to the RFC3339 representation of value. Nil and zero
+// timestamps are skipped.
+func querySetTimestamp(query url.Values, key string, value *time.Time) {
+	if value == nil || value.IsZero() {
+		return
+	}
+	query.Set(key, value.Format(time.RFC3339))
+}
+
+// querySetDate sets key to the date-only representation of value. Nil and zero dates
+// are skipped.
+func querySetDate(query url.Values, key string, value *twapi.Date) {
+	if value == nil || value.IsZero() {
+		return
+	}
+	query.Set(key, value.String())
+}
+
+// querySetBool sets key to value. Only nil is skipped: an explicit false is sent, so
+// callers can override an API default that is true.
+func querySetBool(query url.Values, key string, value *bool) {
+	if value == nil {
+		return
+	}
+	query.Set(key, strconv.FormatBool(*value))
+}
+
+// querySetInt64s sets key to the comma-separated list of values. An empty list is
+// skipped.
+func querySetInt64s(query url.Values, key string, values []int64) {
+	if len(values) == 0 {
+		return
+	}
+	formatted := make([]string, len(values))
+	for i, value := range values {
+		formatted[i] = strconv.FormatInt(value, 10)
+	}
+	query.Set(key, strings.Join(formatted, ","))
+}

--- a/projects/query_test.go
+++ b/projects/query_test.go
@@ -1,0 +1,267 @@
+package projects
+
+// This is the only in-package test file for the projects package — every other
+// test lives in projects_test. The querySet* helpers are unexported, so they can
+// only be exercised from inside the package.
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	twapi "github.com/teamwork/twapi-go-sdk"
+)
+
+// testEnum is a stand-in for the typed string enums the SDK uses for filter
+// values (order-by keys, sideloads, status values). It exercises querySetString
+// through its generic ~string contract rather than depending on any particular
+// resource's enum.
+type testEnum string
+
+const testEnumValue testEnum = "createdAt"
+
+// assertQuery checks that query holds exactly the expected key when want is
+// non-empty, and is untouched when want is empty. Every querySet* helper is a
+// no-op for unset values, so "wrote nothing at all" is the assertion that
+// matters most.
+func assertQuery(t *testing.T, query url.Values, key, want string) {
+	t.Helper()
+
+	if want == "" {
+		if len(query) != 0 {
+			t.Errorf("expected no query params, got %v", query)
+		}
+		return
+	}
+	if got := query.Get(key); got != want {
+		t.Errorf("%s = %q, want %q", key, got, want)
+	}
+	if len(query) != 1 {
+		t.Errorf("expected only %s to be set, got %v", key, query)
+	}
+}
+
+func TestQuerySetString(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{{
+		name:  "empty string writes nothing",
+		value: "",
+		want:  "",
+	}, {
+		name:  "value is set",
+		value: "urgent",
+		want:  "urgent",
+	}, {
+		name:  "whitespace is not treated as empty",
+		value: " ",
+		want:  " ",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := url.Values{}
+			querySetString(query, "searchTerm", tt.value)
+			assertQuery(t, query, "searchTerm", tt.want)
+		})
+	}
+}
+
+func TestQuerySetStringTypedEnum(t *testing.T) {
+	query := url.Values{}
+	querySetString(query, "orderBy", testEnumValue)
+	assertQuery(t, query, "orderBy", "createdAt")
+
+	empty := url.Values{}
+	querySetString(empty, "orderBy", testEnum(""))
+	assertQuery(t, empty, "orderBy", "")
+}
+
+func TestQuerySetInt64(t *testing.T) {
+	tests := []struct {
+		name  string
+		value int64
+		want  string
+	}{{
+		name:  "zero writes nothing",
+		value: 0,
+		want:  "",
+	}, {
+		// Documented behaviour: non-positive means unset, matching the `> 0`
+		// guard every int64 filter in the SDK used before these helpers existed.
+		name:  "negative writes nothing",
+		value: -1,
+		want:  "",
+	}, {
+		name:  "positive is set",
+		value: 42,
+		want:  "42",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := url.Values{}
+			querySetInt64(query, "page", tt.value)
+			assertQuery(t, query, "page", tt.want)
+		})
+	}
+}
+
+func TestQuerySetBool(t *testing.T) {
+	trueValue, falseValue := true, false
+
+	tests := []struct {
+		name  string
+		value *bool
+		want  string
+	}{{
+		name:  "nil writes nothing",
+		value: nil,
+		want:  "",
+	}, {
+		name:  "true is set",
+		value: &trueValue,
+		want:  "true",
+	}, {
+		// An explicit false must reach the API so callers can override a filter
+		// whose server-side default is true.
+		name:  "explicit false is set",
+		value: &falseValue,
+		want:  "false",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := url.Values{}
+			querySetBool(query, "includeCompletedTasks", tt.value)
+			assertQuery(t, query, "includeCompletedTasks", tt.want)
+		})
+	}
+}
+
+func TestQuerySetTimestamp(t *testing.T) {
+	value := time.Date(2026, time.July, 27, 14, 30, 5, 0, time.UTC)
+	var zero time.Time
+
+	tests := []struct {
+		name  string
+		value *time.Time
+		want  string
+	}{{
+		name:  "nil writes nothing",
+		value: nil,
+		want:  "",
+	}, {
+		name:  "zero timestamp writes nothing",
+		value: &zero,
+		want:  "",
+	}, {
+		name:  "value is formatted as RFC3339",
+		value: &value,
+		want:  "2026-07-27T14:30:05Z",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := url.Values{}
+			querySetTimestamp(query, "createdAfter", tt.value)
+			assertQuery(t, query, "createdAfter", tt.want)
+		})
+	}
+}
+
+func TestQuerySetDate(t *testing.T) {
+	value := twapi.Date(time.Date(2026, time.July, 27, 14, 30, 5, 0, time.UTC))
+	var zero twapi.Date
+
+	tests := []struct {
+		name  string
+		value *twapi.Date
+		want  string
+	}{{
+		name:  "nil writes nothing",
+		value: nil,
+		want:  "",
+	}, {
+		name:  "zero date writes nothing",
+		value: &zero,
+		want:  "",
+	}, {
+		name:  "value is formatted as a date, dropping the time",
+		value: &value,
+		want:  "2026-07-27",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := url.Values{}
+			querySetDate(query, "dueAfter", tt.value)
+			assertQuery(t, query, "dueAfter", tt.want)
+		})
+	}
+}
+
+func TestQuerySetInt64s(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []int64
+		want   string
+	}{{
+		name:   "nil writes nothing",
+		values: nil,
+		want:   "",
+	}, {
+		name:   "empty slice writes nothing",
+		values: []int64{},
+		want:   "",
+	}, {
+		name:   "single value",
+		values: []int64{1},
+		want:   "1",
+	}, {
+		name:   "multiple values are comma separated in caller order",
+		values: []int64{3, 1, 2},
+		want:   "3,1,2",
+	}, {
+		// Unlike querySetInt64, the slice helper does not treat non-positive
+		// values as unset: a caller that passes them meant to send them.
+		name:   "non-positive values are kept",
+		values: []int64{0, -1},
+		want:   "0,-1",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := url.Values{}
+			querySetInt64s(query, "tagIds", tt.values)
+			assertQuery(t, query, "tagIds", tt.want)
+		})
+	}
+}
+
+// TestQuerySetHelpersDoNotClobber verifies the helpers accumulate into a shared
+// url.Values, which is how every filter's apply method uses them.
+func TestQuerySetHelpersDoNotClobber(t *testing.T) {
+	completed := true
+	createdAfter := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+	query := url.Values{}
+	querySetString(query, "searchTerm", "urgent")
+	querySetInt64(query, "pageSize", 50)
+	querySetBool(query, "includeCompletedTasks", &completed)
+	querySetTimestamp(query, "createdAfter", &createdAfter)
+	querySetInt64s(query, "tagIds", []int64{7, 8})
+
+	want := url.Values{
+		"searchTerm":            []string{"urgent"},
+		"pageSize":              []string{"50"},
+		"includeCompletedTasks": []string{"true"},
+		"createdAfter":          []string{"2026-01-02T03:04:05Z"},
+		"tagIds":                []string{"7,8"},
+	}
+	if got := query.Encode(); got != want.Encode() {
+		t.Errorf("query = %q, want %q", got, want.Encode())
+	}
+}

--- a/projects/task.go
+++ b/projects/task.go
@@ -778,6 +778,16 @@ type TaskListRequestFilters struct {
 	// specific date and time.
 	CompletedBefore *time.Time
 
+	// IncludeCompletedTasks indicates whether to include completed tasks in the
+	// results. When nil or false, completed tasks are excluded (the API default).
+	// Set to true to include them.
+	IncludeCompletedTasks *bool
+
+	// IncludeTasksFromCompletedTasklists indicates whether to include tasks that
+	// belong to completed tasklists. When nil or false, those tasks are excluded
+	// (the API default). Set to true to include them.
+	IncludeTasksFromCompletedTasklists *bool
+
 	// DueAfter is an optional filter to retrieve tasks due after a specific date.
 	DueAfter *twapi.Date
 
@@ -851,6 +861,12 @@ func (t TaskListRequestFilters) apply(req *http.Request) {
 	}
 	if t.CompletedBefore != nil && !t.CompletedBefore.IsZero() {
 		query.Set("completedBefore", t.CompletedBefore.Format(time.RFC3339))
+	}
+	if t.IncludeCompletedTasks != nil {
+		query.Set("includeCompletedTasks", strconv.FormatBool(*t.IncludeCompletedTasks))
+	}
+	if t.IncludeTasksFromCompletedTasklists != nil {
+		query.Set("showCompletedLists", strconv.FormatBool(*t.IncludeTasksFromCompletedTasklists))
 	}
 	if t.DueAfter != nil && !t.DueAfter.IsZero() {
 		query.Set("dueAfter", t.DueAfter.String())

--- a/projects/task.go
+++ b/projects/task.go
@@ -827,75 +827,25 @@ func (t TaskListRequestFilters) apply(req *http.Request) {
 	t.TaskRequestFilters.apply(req)
 
 	query := req.URL.Query()
-	if t.SearchTerm != "" {
-		query.Set("searchTerm", t.SearchTerm)
-	}
-	if len(t.AssigneeUserIDs) > 0 {
-		assigneeUserIDs := make([]string, len(t.AssigneeUserIDs))
-		for i, id := range t.AssigneeUserIDs {
-			assigneeUserIDs[i] = strconv.FormatInt(id, 10)
-		}
-		query.Set("responsiblePartyIds", strings.Join(assigneeUserIDs, ","))
-	}
-	if t.CreatedAfter != nil && !t.CreatedAfter.IsZero() {
-		query.Set("createdAfter", t.CreatedAfter.Format(time.RFC3339))
-	}
-	if t.CreatedBefore != nil && !t.CreatedBefore.IsZero() {
-		query.Set("createdBefore", t.CreatedBefore.Format(time.RFC3339))
-	}
-	if len(t.CreatedByUserIDs) > 0 {
-		createdByUserIDs := make([]string, len(t.CreatedByUserIDs))
-		for i, id := range t.CreatedByUserIDs {
-			createdByUserIDs[i] = strconv.FormatInt(id, 10)
-		}
-		query.Set("createdByUserIds", strings.Join(createdByUserIDs, ","))
-	}
-	if t.UpdatedAfter != nil && !t.UpdatedAfter.IsZero() {
-		query.Set("updatedAfter", t.UpdatedAfter.Format(time.RFC3339))
-	}
-	if t.UpdatedBefore != nil && !t.UpdatedBefore.IsZero() {
-		query.Set("updatedBefore", t.UpdatedBefore.Format(time.RFC3339))
-	}
-	if t.CompletedAfter != nil && !t.CompletedAfter.IsZero() {
-		query.Set("completedAfter", t.CompletedAfter.Format(time.RFC3339))
-	}
-	if t.CompletedBefore != nil && !t.CompletedBefore.IsZero() {
-		query.Set("completedBefore", t.CompletedBefore.Format(time.RFC3339))
-	}
-	if t.IncludeCompletedTasks != nil {
-		query.Set("includeCompletedTasks", strconv.FormatBool(*t.IncludeCompletedTasks))
-	}
-	if t.IncludeTasksFromCompletedTasklists != nil {
-		query.Set("showCompletedLists", strconv.FormatBool(*t.IncludeTasksFromCompletedTasklists))
-	}
-	if t.DueAfter != nil && !t.DueAfter.IsZero() {
-		query.Set("dueAfter", t.DueAfter.String())
-	}
-	if t.DueBefore != nil && !t.DueBefore.IsZero() {
-		query.Set("dueBefore", t.DueBefore.String())
-	}
-	if len(t.TagIDs) > 0 {
-		tagIDs := make([]string, len(t.TagIDs))
-		for i, id := range t.TagIDs {
-			tagIDs[i] = strconv.FormatInt(id, 10)
-		}
-		query.Set("tagIds", strings.Join(tagIDs, ","))
-	}
-	if t.MatchAllTags != nil {
-		query.Set("matchAllTags", strconv.FormatBool(*t.MatchAllTags))
-	}
-	if t.OnlyUnassigned != nil {
-		query.Set("onlyUnassignedTasks", strconv.FormatBool(*t.OnlyUnassigned))
-	}
-	if t.OnlyUnplanned != nil {
-		query.Set("onlyUnplanned", strconv.FormatBool(*t.OnlyUnplanned))
-	}
-	if t.Page > 0 {
-		query.Set("page", strconv.FormatInt(t.Page, 10))
-	}
-	if t.PageSize > 0 {
-		query.Set("pageSize", strconv.FormatInt(t.PageSize, 10))
-	}
+	querySetString(query, "searchTerm", t.SearchTerm)
+	querySetInt64s(query, "responsiblePartyIds", t.AssigneeUserIDs)
+	querySetTimestamp(query, "createdAfter", t.CreatedAfter)
+	querySetTimestamp(query, "createdBefore", t.CreatedBefore)
+	querySetInt64s(query, "createdByUserIds", t.CreatedByUserIDs)
+	querySetTimestamp(query, "updatedAfter", t.UpdatedAfter)
+	querySetTimestamp(query, "updatedBefore", t.UpdatedBefore)
+	querySetTimestamp(query, "completedAfter", t.CompletedAfter)
+	querySetTimestamp(query, "completedBefore", t.CompletedBefore)
+	querySetBool(query, "includeCompletedTasks", t.IncludeCompletedTasks)
+	querySetBool(query, "showCompletedLists", t.IncludeTasksFromCompletedTasklists)
+	querySetDate(query, "dueAfter", t.DueAfter)
+	querySetDate(query, "dueBefore", t.DueBefore)
+	querySetInt64s(query, "tagIds", t.TagIDs)
+	querySetBool(query, "matchAllTags", t.MatchAllTags)
+	querySetBool(query, "onlyUnassignedTasks", t.OnlyUnassigned)
+	querySetBool(query, "onlyUnplanned", t.OnlyUnplanned)
+	querySetInt64(query, "page", t.Page)
+	querySetInt64(query, "pageSize", t.PageSize)
 	t.Fields.apply(query)
 	req.URL.RawQuery = query.Encode()
 }


### PR DESCRIPTION
## Description

Add two optional `*bool` filters to `TaskListRequestFilters`: `IncludeCompletedTasks`, mapping to the `includeCompletedTasks` query parameter, and `IncludeTasksFromCompletedTasklists`, mapping to `showCompletedLists`. When `nil` (the default), each parameter is omitted, and the API's default behaviour of excluding completed tasks and tasks belonging to completed tasklists is preserved; set them to true to include those tasks in the results.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors