### PR TITLE
Fix: ProjectBudget - Add Page filter and correct updatedByUserId tag

### DIFF
--- a/projects/project_budget.go
+++ b/projects/project_budget.go
@@ -171,7 +171,7 @@ type ProjectBudget struct {
 	CreatedAt *time.Time `json:"dateCreated"`
 
 	// UpdatedBy is the identifier of the user who last updated this budget.
-	UpdatedBy *int64 `json:"updatedUserId"`
+	UpdatedBy *int64 `json:"updatedByUserId"`
 
 	// UpdatedAt is the date and time when this budget was last updated.
 	UpdatedAt *time.Time `json:"dateUpdated"`
@@ -198,12 +198,27 @@ type ProjectBudgetListRequestFilters struct {
 	Status ProjectBudgetStatus
 
 	// Limit limits the number of items returned by the endpoint.
+	//
+	// Limit only applies to cursor pagination. When Cursor is empty the
+	// endpoint pages with Page/PageSize and Limit is ignored.
 	Limit int64
 
-	// PageSize sets the number of items per page.
+	// Page selects the 1-based page of results. The response reports the
+	// resulting offset as Meta.Page.PageOffset, which is Page-1.
+	//
+	// Page is ignored when Cursor is set.
+	Page int64
+
+	// PageSize sets the number of items per page. The endpoint caps this at
+	// 500.
+	//
+	// PageSize is ignored when Cursor is set.
 	PageSize int64
 
-	// Cursor is the pagination cursor used by the endpoint.
+	// Cursor is the pagination cursor used by the endpoint. It must be an
+	// opaque cursor returned by a previous response; it is not an offset or a
+	// page number. Setting it switches the endpoint into cursor pagination,
+	// where Page and PageSize are ignored and Limit bounds the page.
 	Cursor string
 
 	// Fields restricts the attributes returned for the project budget and each
@@ -228,6 +243,9 @@ func (p ProjectBudgetListRequestFilters) apply(req *http.Request) {
 	}
 	if p.Limit > 0 {
 		query.Set("limit", strconv.FormatInt(p.Limit, 10))
+	}
+	if p.Page > 0 {
+		query.Set("page", strconv.FormatInt(p.Page, 10))
 	}
 	if p.PageSize > 0 {
 		query.Set("pageSize", strconv.FormatInt(p.PageSize, 10))

--- a/projects/project_budget.go
+++ b/projects/project_budget.go
@@ -171,7 +171,7 @@ type ProjectBudget struct {
 	CreatedAt *time.Time `json:"dateCreated"`
 
 	// UpdatedBy is the identifier of the user who last updated this budget.
-	UpdatedBy *int64 `json:"updatedByUserId"`
+	UpdatedBy *int64 `json:"updatedBy"`
 
 	// UpdatedAt is the date and time when this budget was last updated.
 	UpdatedAt *time.Time `json:"dateUpdated"`

--- a/projects/project_budget_test.go
+++ b/projects/project_budget_test.go
@@ -46,6 +46,29 @@ func TestProjectBudgetListRequestGeneration(t *testing.T) {
 	}
 }
 
+func TestProjectBudgetListRequestGeneration_Page(t *testing.T) {
+	req := projects.NewProjectBudgetListRequest()
+	req.Filters.Page = 3
+	req.Filters.PageSize = 250
+
+	httpReq, err := req.HTTPRequest(context.Background(), "https://test.com")
+	if err != nil {
+		t.Fatalf("unexpected error creating HTTP request: %s", err)
+	}
+
+	query, err := url.ParseQuery(httpReq.URL.RawQuery)
+	if err != nil {
+		t.Fatalf("failed to parse query string: %s", err)
+	}
+
+	if query.Get("page") != "3" {
+		t.Errorf("expected page=3 but got %q", query.Get("page"))
+	}
+	if query.Get("pageSize") != "250" {
+		t.Errorf("expected pageSize=250 but got %q", query.Get("pageSize"))
+	}
+}
+
 func TestProjectBudgetListRequestGeneration_AllOptional(t *testing.T) {
 	req := projects.NewProjectBudgetListRequest()
 

--- a/projects/sparse_fields_gen.go
+++ b/projects/sparse_fields_gen.go
@@ -307,7 +307,7 @@ const (
 	ProjectBudgetFieldNotificationIDs    ProjectBudgetField = "notificationIds"
 	ProjectBudgetFieldCreatedBy          ProjectBudgetField = "createdByUserId"
 	ProjectBudgetFieldCreatedAt          ProjectBudgetField = "dateCreated"
-	ProjectBudgetFieldUpdatedBy          ProjectBudgetField = "updatedUserId"
+	ProjectBudgetFieldUpdatedBy          ProjectBudgetField = "updatedByUserId"
 	ProjectBudgetFieldUpdatedAt          ProjectBudgetField = "dateUpdated"
 	ProjectBudgetFieldCompletedBy        ProjectBudgetField = "completedByUserId"
 	ProjectBudgetFieldCompletedAt        ProjectBudgetField = "dateCompleted"

--- a/projects/sparse_fields_gen.go
+++ b/projects/sparse_fields_gen.go
@@ -307,7 +307,7 @@ const (
 	ProjectBudgetFieldNotificationIDs    ProjectBudgetField = "notificationIds"
 	ProjectBudgetFieldCreatedBy          ProjectBudgetField = "createdByUserId"
 	ProjectBudgetFieldCreatedAt          ProjectBudgetField = "dateCreated"
-	ProjectBudgetFieldUpdatedBy          ProjectBudgetField = "updatedByUserId"
+	ProjectBudgetFieldUpdatedBy          ProjectBudgetField = "updatedBy"
 	ProjectBudgetFieldUpdatedAt          ProjectBudgetField = "dateUpdated"
 	ProjectBudgetFieldCompletedBy        ProjectBudgetField = "completedByUserId"
 	ProjectBudgetFieldCompletedAt        ProjectBudgetField = "dateCompleted"


### PR DESCRIPTION
ProjectBudgetListRequestFilters had no Page field, so callers had no way to advance through results. The only pagination controls exposed were PageSize and Cursor, and Cursor takes an opaque value returned by a previous response — there was nothing a caller could set to reach page two. Requests that asked for more than one page silently received the first page repeatedly, with Meta.Page.PageOffset pinned at 0 while Meta.Page.HasMore stayed true.

Add Page, mapping to the page query parameter. The endpoint follows the usual v3 convention where page is 1-based and the response reports the resulting offset as pageOffset, which is page-1.

Also document that the two pagination modes are mutually exclusive. Setting Cursor switches the endpoint into cursor pagination, where page and pageSize are ignored and limit bounds the page instead; leaving it empty pages with Page/PageSize and ignores Limit. Nothing in the previous comments distinguished the two, which is what made Cursor look like an offset.

Separately, ProjectBudget.UpdatedBy was tagged updatedUserId, but the API returns updatedByUserId, mirroring createdByUserId. The field therefore never decoded and always stayed nil. Because the sparse-field constants are generated from these tags,
ProjectBudgetFieldUpdatedBy also carried the wrong attribute name and would have been rejected in a fields[budgets] selection. Fix the tag and regenerate.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [x] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added necessary documentation
- [ ] No new warnings or errors