### PR TITLE
Fix: ProjectBudget - Send sparse fields as fields[projectBudgets]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,9 +327,25 @@ Then run `go generate ./...` from the package directory (or the repo root). The 
 #### What the generator emits
 
 - `type <Entity>Field string` plus one constant per JSON-tagged attribute of the entity (same-package embedded structs are flattened; an outer struct's tag shadows the embed's).
-- `type <Resource>ListFields struct { ... }` with one typed slice per slot — the main list slice **and** each map field inside the response's `Included` struct. Slot names mirror the response's Go field names; entity keys come from the response's JSON tags.
+- `type <Resource>ListFields struct { ... }` with one typed slice per slot — the main list slice **and** each map field inside the response's `Included` struct. Slot names mirror the response's Go field names; entity keys come from the response's JSON tags unless overridden with `sparsefields:key` (see below).
 - `func (f <Resource>ListFields) apply(query url.Values)` writing every populated slot via `twapi.ApplySparseFields`.
 - A pair of generated tests per wired list: `Test<Resource>ListFieldsApply` and `Test<Resource>ListFieldsZeroValue`.
+
+#### When the envelope key isn't the entity name
+
+Entity keys default to the JSON tag of the response field, which is correct whenever the response envelope key matches the entity name the API recognises — the usual case (`{"tasks":[…]}` ↔ `fields[tasks]`). A few endpoints diverge: `/projects/api/v3/projects/budgets.json` wraps its payload in `budgets` while the entity is `projectBudgets`. Declare the divergence with a `sparsefields:key=<entityName>` marker on the response field — as a doc comment or a trailing line comment:
+
+```go
+type ProjectBudgetListResponse struct {
+    // The endpoint wraps its payload in "budgets", but the entity name the API
+    // recognises for sparse fieldsets and sideloads is "projectBudgets", so the
+    // fields[...] key can't be derived from the json tag here.
+    //
+    // sparsefields:key=projectBudgets
+    Budgets []ProjectBudget `json:"budgets"`
+```
+
+The marker only changes the emitted `fields[...]` key; the JSON tag still drives decoding. It works on `Included` sideload fields too. When in doubt, check the endpoint's apidocs page for the `fields[…]` parameter name rather than assuming it matches the envelope — an unrecognised key is silently ignored by the API, so the whole selection degrades to "return everything" with no error.
 
 #### When *not* to mark a response
 
@@ -342,6 +358,8 @@ In both cases the SDK still works — the endpoint simply can't expose typed spa
 
 - The generator fails fast if a marked response references an entity type that *isn't* marked with `sparsefields:gen` — every slot must resolve to a `<Entity>Field` enum.
 - The generator also fails if a filter declares `Fields <Container>` but no method on that filter type ever calls `<receiver>.Fields.apply(...)` — that catches the easy mistake of adding the slot but forgetting to wire it into the request.
+- A `sparsefields:key` marker with no value, or one containing characters that can't appear in an entity name (` `, `,`, `[`, `]`, `=`), is a generate-time error rather than a bad query parameter.
+- Two slots of the same list resolving to the same `fields[...]` key is a generate-time error — otherwise one would silently overwrite the other in `apply`.
 - CI runs `go generate ./...` on a clean checkout and fails if anything changes, so stale generated code can't merge.
 
 ---

--- a/internal/sparsefieldsgen/main.go
+++ b/internal/sparsefieldsgen/main.go
@@ -16,6 +16,16 @@
 //     that writes the appropriate fields[entityKey]=… query parameters via
 //     twapi.ApplySparseFields.
 //
+// A third marker applies to individual fields of a marked *ListResponse:
+//
+//   - sparsefields:key=entityName
+//     Overrides the fields[...] entity key for that slot. The key otherwise
+//     defaults to the field's json tag, which is right whenever the response
+//     envelope key matches the entity name the API recognises. A handful of
+//     endpoints break that assumption — /projects/api/v3/projects/budgets.json
+//     wraps its payload in "budgets" while the entity is "projectBudgets" — and
+//     this marker is how they declare the divergence.
+//
 // Usage (typically invoked via //go:generate from the target package):
 //
 //	//go:generate go run github.com/teamwork/twapi-go-sdk/internal/sparsefieldsgen
@@ -46,6 +56,7 @@ import (
 const (
 	markerEntity = "sparsefields:gen"
 	markerList   = "sparsefields:list"
+	markerKey    = "sparsefields:key"
 
 	rootImportPath = "github.com/teamwork/twapi-go-sdk"
 	rootImportName = "twapi"
@@ -433,6 +444,9 @@ func collectLists(file *ast.File, fieldTypeOf map[string]string, dst *[]listResp
 			if len(slots) == 0 {
 				log.Fatalf("sparsefieldsgen: %s has no sparse-fields slots (no slice field nor Included struct)", ts.Name.Name)
 			}
+			if err := assertUniqueEntityKeys(slots, ts.Name.Name); err != nil {
+				log.Fatalf("sparsefieldsgen: %v", err)
+			}
 			*dst = append(*dst, listResponse{
 				StructName:    ts.Name.Name,
 				ContainerName: container,
@@ -476,6 +490,47 @@ func markerOverride(doc *ast.CommentGroup, marker, defaultName string) (string, 
 		}
 	}
 	return "", false
+}
+
+// slotEntityKey resolves the fields[...] entity key for one slot of a marked
+// *ListResponse. It defaults to jsonTag — the response envelope key and the
+// entity name coincide for nearly every v3 list — and honours a
+// `sparsefields:key=<name>` marker on the field's doc comment or trailing
+// comment for the endpoints where the two diverge.
+//
+// The override is rejected when empty or when it contains characters that can't
+// appear in a query-parameter entity name, so a typo fails at generate time
+// rather than producing a fields[...] key the API silently ignores.
+func slotEntityKey(field *ast.Field, jsonTag, what string) (string, error) {
+	for _, doc := range []*ast.CommentGroup{field.Doc, field.Comment} {
+		key, ok := markerOverride(doc, markerKey, "")
+		if !ok {
+			continue
+		}
+		switch {
+		case key == "":
+			return "", fmt.Errorf("%s carries `%s` without a value; use `%s=entityName`", what, markerKey, markerKey)
+		case strings.ContainsAny(key, " \t,[]="):
+			return "", fmt.Errorf("%s declares an invalid `%s` value %q", what, markerKey, key)
+		}
+		return key, nil
+	}
+	return jsonTag, nil
+}
+
+// assertUniqueEntityKeys fails when two slots of the same list target the same
+// fields[...] key, which would make one silently overwrite the other in the
+// generated apply method. Only reachable through a `sparsefields:key` override,
+// since json tags are unique within a struct.
+func assertUniqueEntityKeys(slots []slot, ownerName string) error {
+	seen := make(map[string]string, len(slots))
+	for _, s := range slots {
+		if other, ok := seen[s.EntityKey]; ok {
+			return fmt.Errorf("slots %s and %s of %s both target fields[%s]", other, s.GoName, ownerName, s.EntityKey)
+		}
+		seen[s.EntityKey] = s.GoName
+	}
+	return nil
 }
 
 // extractFields returns the json-tagged fields of a struct, in source order.
@@ -591,9 +646,13 @@ func extractSlots(st *ast.StructType, ownerName string, fieldTypeOf map[string]s
 				return nil, fmt.Errorf("slice field %s.%s uses element type %s which has no `%s` marker",
 					ownerName, field.Names[0].Name, elem.Name, markerEntity)
 			}
+			entityKey, err := slotEntityKey(field, jsonTag, fmt.Sprintf("slice field %s.%s", ownerName, field.Names[0].Name))
+			if err != nil {
+				return nil, err
+			}
 			slots = append(slots, slot{
 				GoName:      field.Names[0].Name,
-				EntityKey:   jsonTag,
+				EntityKey:   entityKey,
 				ElementType: fieldType,
 			})
 		case *ast.StructType:
@@ -641,9 +700,14 @@ func extractIncludedSlots(st *ast.StructType, ownerName string, fieldTypeOf map[
 		if jsonTag == "" || jsonTag == "-" {
 			continue
 		}
+		entityKey, err := slotEntityKey(field, jsonTag,
+			fmt.Sprintf("sideload %s.Included.%s", ownerName, field.Names[0].Name))
+		if err != nil {
+			return nil, err
+		}
 		slots = append(slots, slot{
 			GoName:      field.Names[0].Name,
-			EntityKey:   jsonTag,
+			EntityKey:   entityKey,
 			ElementType: fieldType,
 		})
 	}

--- a/projects/project_budget.go
+++ b/projects/project_budget.go
@@ -289,6 +289,11 @@ func (p ProjectBudgetListRequest) HTTPRequest(ctx context.Context, server string
 //
 // sparsefields:list
 type ProjectBudgetListResponse struct {
+	// The endpoint wraps its payload in "budgets", but the entity name the API
+	// recognises for sparse fieldsets and sideloads is "projectBudgets", so the
+	// fields[...] key can't be derived from the json tag here.
+	//
+	// sparsefields:key=projectBudgets
 	Budgets []ProjectBudget `json:"budgets"`
 
 	Meta struct {

--- a/projects/sparse_fields_gen.go
+++ b/projects/sparse_fields_gen.go
@@ -762,13 +762,13 @@ func (f NotebookListFields) apply(query url.Values) {
 // ProjectBudgetListFields selects sparse-fields slots for ProjectBudgetListResponse. Leave a slot empty to receive the
 // API default for that entity; populate it to restrict the attributes returned.
 type ProjectBudgetListFields struct {
-	// Budgets controls fields[budgets]=… on the response.
+	// Budgets controls fields[projectBudgets]=… on the response.
 	Budgets []ProjectBudgetField
 }
 
 // apply writes every populated slot to query as a fields[entity]=… parameter.
 func (f ProjectBudgetListFields) apply(query url.Values) {
-	twapi.ApplySparseFields(query, "budgets", f.Budgets)
+	twapi.ApplySparseFields(query, "projectBudgets", f.Budgets)
 }
 
 // ProjectCategoryListFields selects sparse-fields slots for ProjectCategoryListResponse. Leave a slot empty to receive the

--- a/projects/sparse_fields_gen_test.go
+++ b/projects/sparse_fields_gen_test.go
@@ -436,7 +436,7 @@ func TestProjectBudgetListFieldsApply(t *testing.T) {
 	query := url.Values{}
 	fields.apply(query)
 	checks := map[string]string{
-		"fields[budgets]": "id",
+		"fields[projectBudgets]": "id",
 	}
 	for key, want := range checks {
 		if got := query.Get(key); got != want {


### PR DESCRIPTION
## Description

The endpoint's envelope key is "budgets", but the entity is "projectBudgets", so sparsefieldsgen derived the wrong key from the JSON tag, and the API silently ignored the selection. Add a field-level `sparsefields:key` marker for lists where the two names diverge.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors