### PR TITLE
Fix: CalendarEvent - Send sparse fields as fields[calendarsEvents]

### DIFF
--- a/projects/calendar_event.go
+++ b/projects/calendar_event.go
@@ -371,6 +371,12 @@ type CalendarEventListResponse struct {
 	} `json:"meta"`
 
 	// Events contains the calendar events.
+	//
+	// The endpoint returns its payload under "events", but the sparse-fieldsets
+	// query parameter it binds is "fields[calendarsEvents]", so the key can't be
+	// derived from the json tag here.
+	//
+	// sparsefields:key=calendarsEvents
 	Events []CalendarEvent `json:"events"`
 
 	// Included contains related objects included in the response.

--- a/projects/sparse_fields_gen.go
+++ b/projects/sparse_fields_gen.go
@@ -594,7 +594,7 @@ func (f ActivityListFields) apply(query url.Values) {
 // CalendarEventListFields selects sparse-fields slots for CalendarEventListResponse. Leave a slot empty to receive the
 // API default for that entity; populate it to restrict the attributes returned.
 type CalendarEventListFields struct {
-	// Events controls fields[events]=… on the response.
+	// Events controls fields[calendarsEvents]=… on the response.
 	Events []CalendarEventField
 	// Users controls fields[users]=… on the response.
 	Users []UserField
@@ -612,7 +612,7 @@ type CalendarEventListFields struct {
 
 // apply writes every populated slot to query as a fields[entity]=… parameter.
 func (f CalendarEventListFields) apply(query url.Values) {
-	twapi.ApplySparseFields(query, "events", f.Events)
+	twapi.ApplySparseFields(query, "calendarsEvents", f.Events)
 	twapi.ApplySparseFields(query, "users", f.Users)
 	twapi.ApplySparseFields(query, "projects", f.Projects)
 	twapi.ApplySparseFields(query, "tasks", f.Tasks)

--- a/projects/sparse_fields_gen_test.go
+++ b/projects/sparse_fields_gen_test.go
@@ -54,13 +54,13 @@ func TestCalendarEventListFieldsApply(t *testing.T) {
 	query := url.Values{}
 	fields.apply(query)
 	checks := map[string]string{
-		"fields[events]":    "id",
-		"fields[users]":     "id",
-		"fields[projects]":  "id",
-		"fields[tasks]":     "id",
-		"fields[tasklists]": "id",
-		"fields[companies]": "id",
-		"fields[timelogs]":  "id",
+		"fields[calendarsEvents]": "id",
+		"fields[users]":           "id",
+		"fields[projects]":        "id",
+		"fields[tasks]":           "id",
+		"fields[tasklists]":       "id",
+		"fields[companies]":       "id",
+		"fields[timelogs]":        "id",
 	}
 	for key, want := range checks {
 		if got := query.Get(key); got != want {


### PR DESCRIPTION
## Description

The events endpoint binds fields[calendarsEvents], not the fields[events] key derived from the response json tag.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally (`go test -v ./...`)
- [x] Added/updated tests for new functionality

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added necessary documentation
- [x] No new warnings or errors