### PR TITLE
Support adding colors to tags in the Teamwork API SDK.

### DIFF
--- a/projects/sparse_fields_gen.go
+++ b/projects/sparse_fields_gen.go
@@ -389,6 +389,7 @@ type TagField string
 const (
 	TagFieldID      TagField = "id"
 	TagFieldName    TagField = "name"
+	TagFieldColor   TagField = "color"
 	TagFieldProject TagField = "project"
 )
 

--- a/projects/tag.go
+++ b/projects/tag.go
@@ -63,6 +63,9 @@ type Tag struct {
 	// Name is the name of the tag.
 	Name string `json:"name"`
 
+	// Color is the color of the tag, represented as a hexadecimal color code.
+	Color string `json:"color"`
+
 	// Project is the project the tag belongs to.
 	Project *twapi.Relationship `json:"project"`
 }
@@ -75,15 +78,21 @@ type TagCreateRequest struct {
 	// 50 characters.
 	Name string `json:"name"`
 
+	// Color is the color of the tag, represented as a hexadecimal color code. This
+	// field is optional. If not provided, a default color will be assigned.
+	Color *string `json:"color,omitempty"`
+
 	// ProjectID is the unique identifier of the project the tag belongs to. This
 	// is for project-scoped tags.
 	ProjectID *int64 `json:"projectId,omitempty"`
 }
 
 // NewTagCreateRequest creates a new TagCreateRequest with the provided name.
-func NewTagCreateRequest(name string) TagCreateRequest {
+func NewTagCreateRequest(name string, color *string, projectID *int64) TagCreateRequest {
 	return TagCreateRequest{
-		Name: name,
+		Name:      name,
+		Color:     color,
+		ProjectID: projectID,
 	}
 }
 
@@ -161,6 +170,10 @@ type TagUpdateRequest struct {
 	// Name is the name of the tag. It must be less than 50 characters when
 	// provided.
 	Name *string `json:"name,omitempty"`
+
+	// Color is the color of the tag, represented as a hexadecimal color code. When
+	// provided, it must be a valid hexadecimal color code.
+	Color *string `json:"color,omitempty"`
 
 	// ProjectID is the unique identifier of the project the tag belongs to. This
 	// is for project-scoped tags.

--- a/projects/tag_example_test.go
+++ b/projects/tag_example_test.go
@@ -23,7 +23,7 @@ func ExampleTagCreate() {
 	ctx := context.Background()
 	engine := twapi.NewEngine(session.NewBearerToken("your_token", fmt.Sprintf("http://%s", address)))
 
-	tagResponse, err := projects.TagCreate(ctx, engine, projects.NewTagCreateRequest("Test Tag"))
+	tagResponse, err := projects.TagCreate(ctx, engine, projects.NewTagCreateRequest("Test Tag", new("#e8e8e8"), nil))
 	if err != nil {
 		fmt.Printf("failed to create tag: %s", err)
 	} else {

--- a/projects/tag_test.go
+++ b/projects/tag_test.go
@@ -20,7 +20,7 @@ func TestTagCreate(t *testing.T) {
 		input projects.TagCreateRequest
 	}{{
 		name:  "only required fields",
-		input: projects.NewTagCreateRequest(fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100))),
+		input: projects.NewTagCreateRequest(fmt.Sprintf("test%d%d", time.Now().UnixNano(), rand.Intn(100)), nil, nil),
 	}, {
 		name: "all fields",
 		input: projects.TagCreateRequest{


### PR DESCRIPTION
## Description

This includes updating the Tag struct to include a Color field, modifying the TagCreateRequest struct to accept an optional Color parameter, and updating the NewTagCreateRequest function to handle the new Color parameter. Additionally, test cases and examples have been updated to reflect these changes.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
<!-- How did you test your changes? -->
- [ ] Tests pass locally (`go test -v ./...`)
- [ ] Added/updated tests for new functionality

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added necessary documentation
- [ ] No new warnings or errors